### PR TITLE
`true` is an unsupported argument for newer versions of Redis gem.

### DIFF
--- a/lib/resque/plugins/workers/lock.rb
+++ b/lib/resque/plugins/workers/lock.rb
@@ -59,7 +59,7 @@ module Resque
           if lock_workers(*args)
             lock_result = get_lock_workers(*args)
 
-            if Resque.redis.msetnx lock_result.zip([true]*lock_result.size).flatten
+            if Resque.redis.msetnx lock_result.zip(['true']*lock_result.size).flatten
               lock_result.each do |lock|
                 Resque.redis.expire(lock, worker_lock_timeout(*args))
               end

--- a/resque-workers-lock.gemspec
+++ b/resque-workers-lock.gemspec
@@ -1,11 +1,11 @@
 Gem::Specification.new do |s|
   s.name              = "resque-workers-lock"
-  s.version           = "2.0.1"
+  s.version           = "3.0.0"
   s.date              = Time.now.strftime('%Y-%m-%d')
   s.summary           = "Resque plugin, prevent specific jobs to be processed simultaneously by multiple workers."
   s.homepage          = "http://github.com/bartolsthoorn/resque-workers-lock"
   s.email             = "bartolsthoorn@gmail.com"
-  s.authors           = ["Bart Olsthoorn", "Mike Nicholaides", "Jason Garber", "Tijs Planckaert", "Anton Bogdanovich"]
+  s.authors           = ["Bart Olsthoorn", "Mike Nicholaides", "Jason Garber", "Tijs Planckaert", "Anton Bogdanovich", "Arian Faurtosh"]
   s.licenses          = ["MIT"]
   s.has_rdoc          = false
 

--- a/resque-workers-lock.gemspec
+++ b/resque-workers-lock.gemspec
@@ -9,7 +9,6 @@ Gem::Specification.new do |s|
   s.email             = "bartolsthoorn@gmail.com"
   s.authors           = ["Bart Olsthoorn", "Mike Nicholaides", "Jason Garber", "Tijs Planckaert", "Anton Bogdanovich", "Arian Faurtosh"]
   s.licenses          = ["MIT"]
-  s.has_rdoc          = false
 
   s.files             = %w( README.md Rakefile LICENSE )
   s.files            += Dir.glob("lib/**/*")


### PR DESCRIPTION
Newer version of the Redis gem don't support passing in `TrueClass`.

Previously the Redis client would change these into string `"true"`

```
Unsupported command argument type: TrueClass
/usr/local/bundle/ruby/2.7.0/gems/redis-client-0.17.0/lib/redis_client/command_builder.rb:75:in `block in generate'
/usr/local/bundle/ruby/2.7.0/gems/redis-client-0.17.0/lib/redis_client/command_builder.rb:68:in `map!'
/usr/local/bundle/ruby/2.7.0/gems/redis-client-0.17.0/lib/redis_client/command_builder.rb:68:in `generate'
/usr/local/bundle/ruby/2.7.0/gems/redis-client-0.17.0/lib/redis_client.rb:236:in `call_v'
/usr/local/bundle/ruby/2.7.0/gems/redis-5.0.7/lib/redis/client.rb:90:in `call_v'
/usr/local/bundle/ruby/2.7.0/gems/redis-5.0.7/lib/redis.rb:167:in `block in send_command'
/usr/local/bundle/ruby/2.7.0/gems/redis-5.0.7/lib/redis.rb:166:in `synchronize'
/usr/local/bundle/ruby/2.7.0/gems/redis-5.0.7/lib/redis.rb:166:in `send_command'
/usr/local/bundle/ruby/2.7.0/gems/redis-5.0.7/lib/redis/commands/strings.rb:169:in `msetnx'
/usr/local/bundle/ruby/2.7.0/gems/redis-namespace-1.11.0/lib/redis/namespace.rb:564:in `wrapped_send'
/usr/local/bundle/ruby/2.7.0/gems/redis-namespace-1.11.0/lib/redis/namespace.rb:521:in `call_with_namespace'
/usr/local/bundle/ruby/2.7.0/gems/redis-namespace-1.11.0/lib/redis/namespace.rb:395:in `block (2 levels) in <class:Namespace>'
/usr/local/bundle/ruby/2.7.0/gems/resque-2.6.0/lib/resque/data_store.rb:65:in `method_missing'
/usr/local/bundle/ruby/2.7.0/gems/resque-workers-lock-2.0.1/lib/resque/plugins/workers/lock.rb:62:in `before_perform_workers_lock'
```